### PR TITLE
chore: add Azure DevOps MCP server configuration

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,16 @@
+{
+  "inputs": [
+    {
+      "id": "ado_org",
+      "type": "promptString",
+      "description": "Azure DevOps organization name (e.g. 'contoso')"
+    }
+  ],
+  "servers": {
+    "ado": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@azure-devops/mcp", "${input:ado_org}"]
+    }
+  }
+}


### PR DESCRIPTION
Adds \.vscode/mcp.json\ with Azure DevOps MCP server setup via \
px @azure-devops/mcp\.

## Šta se menja
- Dodat \.vscode/mcp.json\ za lokalni Azure DevOps MCP server

## Kako koristiti
1. Otvori VS Code u ovom projektu
2. Klikni **Start** na MCP baner notifikaciji
3. Unesi naziv ADO organizacije kada se to zatraži
4. Prebaci se na **Agent Mode** u Copilot chatu

> Zahteva Node.js 20+